### PR TITLE
`TxResult` and `BridgeResult` for deposit/withdraw feedback

### DIFF
--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -120,7 +120,7 @@ class BridgeClient:
             deposit_helper=self.deposit_helper,
         )
 
-        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=self.account._private_key)
+        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=self.account._private_key, action="bridge()")
         return tx_result
 
     def bridge_mainnet_eth_to_derive(self, amount: int) -> TxResult:
@@ -136,7 +136,7 @@ class BridgeClient:
         proxy_contract = get_contract(w3=w3, address=address, abi=bridge_abi)
 
         tx = prepare_mainnet_to_derive_gas_tx(w3=w3, account=self.account, amount=amount, proxy_contract=proxy_contract)
-        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.account._private_key)
+        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.account._private_key, action="bridgeETH()")
         return tx_result
 
     def withdraw_with_wrapper(
@@ -208,5 +208,5 @@ class BridgeClient:
             light_account=light_account,
         )
 
-        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=private_key)
+        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=private_key, action="executeBatch()")
         return tx_result

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -41,7 +41,6 @@ from derive_client.data_types import (
     MintableTokenData,
     NonMintableTokenData,
     RPCEndPoints,
-    TxStatus,
     TxResult,
 )
 from derive_client.utils import get_contract, get_erc20_contract, send_and_confirm_tx

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -42,8 +42,9 @@ from derive_client.data_types import (
     NonMintableTokenData,
     RPCEndPoints,
     TxStatus,
+    TxResult,
 )
-from derive_client.utils import get_contract, get_erc20_contract, sign_and_send_tx
+from derive_client.utils import get_contract, get_erc20_contract, send_and_confirm_tx
 
 
 class BridgeClient:
@@ -90,7 +91,7 @@ class BridgeClient:
 
     def deposit(
         self, amount: int, receiver: Address, connector: Address, token_data: NonMintableTokenData | MintableTokenData
-    ):
+    ) -> TxResult:
         """
         Deposit funds by preparing, signing, and sending a bridging transaction.
         """
@@ -119,14 +120,10 @@ class BridgeClient:
             deposit_helper=self.deposit_helper,
         )
 
-        tx_receipt = sign_and_send_tx(self.w3, tx, self.account._private_key)
-        if tx_receipt.status == TxStatus.SUCCESS:
-            print("Deposit successful!")
-            return tx_receipt
-        else:
-            raise Exception("Deposit transaction reverted.")
+        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=self.account._private_key)
+        return tx_result
 
-    def bridge_mainnet_eth_to_derive(self, amount: int) -> dict:
+    def bridge_mainnet_eth_to_derive(self, amount: int) -> TxResult:
         """
         Prepares, signs, and sends a transaction to bridge ETH from mainnet to Derive.
         This is the "socket superbridge" method; not required when using the withdraw wrapper.
@@ -139,13 +136,8 @@ class BridgeClient:
         proxy_contract = get_contract(w3=w3, address=address, abi=bridge_abi)
 
         tx = prepare_mainnet_to_derive_gas_tx(w3=w3, account=self.account, amount=amount, proxy_contract=proxy_contract)
-        tx_receipt = sign_and_send_tx(w3=w3, tx=tx, private_key=self.account._private_key)
-
-        if tx_receipt.status == TxStatus.SUCCESS:
-            print("Bridge deposit successful!")
-            return tx_receipt
-        else:
-            raise Exception("Deposit transaction reverted.")
+        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.account._private_key)
+        return tx_result
 
     def withdraw_with_wrapper(
         self,
@@ -154,7 +146,7 @@ class BridgeClient:
         token_data: MintableTokenData,
         wallet: Address,
         private_key: str,
-    ):
+    ) -> TxResult:
         """
         Checks if sufficent gas is available in derive, if not funds the wallet.
         Prepares, signs, and sends a withdrawal transaction using the withdraw wrapper.
@@ -216,9 +208,5 @@ class BridgeClient:
             light_account=light_account,
         )
 
-        tx_receipt = sign_and_send_tx(w3=self.w3, tx=tx, private_key=private_key)
-        if tx_receipt.status == TxStatus.SUCCESS:
-            print(f"Bridge from Derive to {self.chain_id.name} successful!")
-            return tx_receipt
-        else:
-            raise Exception("Bridge transaction reverted.")
+        tx_result = send_and_confirm_tx(w3=self.w3, tx=tx, private_key=private_key)
+        return tx_result

--- a/derive_client/_bridge/transaction.py
+++ b/derive_client/_bridge/transaction.py
@@ -4,7 +4,7 @@ from web3.contract import Contract
 
 from derive_client.constants import DEFAULT_GAS_FUNDING_AMOUNT, DEPOSIT_GAS_LIMIT, MSG_GAS_LIMIT, PAYLOAD_SIZE
 from derive_client.data_types import Address, ChainID, MintableTokenData, NonMintableTokenData, TxStatus
-from derive_client.utils import estimate_fees, exp_backoff_retry, sign_and_send_tx
+from derive_client.utils import estimate_fees, exp_backoff_retry, send_and_confirm_tx
 
 
 def ensure_balance(token_contract: Contract, owner: Address, amount: int):
@@ -52,15 +52,9 @@ def increase_allowance(
             "gasPrice": w3.eth.gas_price,
         }
     )
-
-    try:
-        tx_receipt = sign_and_send_tx(w3, tx=tx, private_key=private_key)
-        if tx_receipt.status == TxStatus.SUCCESS:
-            print("Transaction succeeded!")
-        else:
-            raise Exception("Transaction reverted.")
-    except Exception as error:
-        raise error
+    tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=private_key, action="approve()")
+    if tx_result.status != TxStatus.SUCCESS:
+        raise RuntimeError("approve() failed")
 
 
 def get_min_fees(

--- a/derive_client/cli.py
+++ b/derive_client/cli.py
@@ -2,7 +2,6 @@
 Cli module in order to allow interaction.
 """
 import os
-import traceback
 from textwrap import dedent
 
 import pandas as pd
@@ -21,8 +20,8 @@ from derive_client.data_types import (
     OrderStatus,
     OrderType,
     SubaccountType,
-    UnderlyingCurrency,
     TxStatus,
+    UnderlyingCurrency,
 )
 from derive_client.derive import DeriveClient
 from derive_client.utils import get_logger

--- a/derive_client/cli.py
+++ b/derive_client/cli.py
@@ -23,7 +23,6 @@ from derive_client.data_types import (
     SubaccountType,
     UnderlyingCurrency,
     TxStatus,
-    TxResult,
 )
 from derive_client.derive import DeriveClient
 from derive_client.utils import get_logger
@@ -139,9 +138,9 @@ def deposit(ctx, chain_id, currency, amount):
     client = ctx.obj["client"]
     receiver = client.wallet
 
-    tx_result = client.deposit_to_derive(chain_id=chain_id, currency=currency, amount=amount, receiver=receiver)
+    bridge_result = client.deposit_to_derive(chain_id=chain_id, currency=currency, amount=amount, receiver=receiver)
 
-    match tx_result.status:
+    match bridge_result.tx_result.status:
         case TxStatus.SUCCESS:
             print(f"[bold green]Deposit from {chain_id.name} to Derive successful![/bold green]")
         case TxStatus.FAILED:
@@ -149,7 +148,7 @@ def deposit(ctx, chain_id, currency, amount):
         case TxStatus.PENDING:
             print(f"[yellow]Deposit from {chain_id.name} to Derive is pending...[/yellow]")
         case _:
-            raise click.ClickException(f"Exception attempting to deposit:\n{tx_result}")
+            raise click.ClickException(f"Exception attempting to deposit:\n{bridge_result}")
 
 
 @bridge.command("withdraw")
@@ -185,9 +184,9 @@ def withdraw(ctx, chain_id, currency, amount):
     client: DeriveClient = ctx.obj["client"]
     receiver = client.signer.address
 
-    tx_result = client.withdraw_from_derive(chain_id=chain_id, currency=currency, amount=amount, receiver=receiver)
+    bridge_result = client.withdraw_from_derive(chain_id=chain_id, currency=currency, amount=amount, receiver=receiver)
 
-    match tx_result.status:
+    match bridge_result.tx_result.status:
         case TxStatus.SUCCESS:
             print(f"[bold green]Withdrawal from Derive to {chain_id.name} successful![/bold green]")
         case TxStatus.FAILED:
@@ -195,7 +194,7 @@ def withdraw(ctx, chain_id, currency, amount):
         case TxStatus.PENDING:
             print(f"[yellow]Withdrawal from Derive to {chain_id.name} is pending...[/yellow]")
         case _:
-            raise click.ClickException(f"Exception attempting to withdraw:\n{tx_result}")
+            raise click.ClickException(f"Exception attempting to withdraw:\n{bridge_result}")
 
 
 @cli.group("instruments")

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -40,6 +40,7 @@ from derive_client.data_types import (
     SubaccountType,
     TimeInForce,
     UnderlyingCurrency,
+    TxResult,
 )
 from derive_client.utils import get_logger, get_prod_derive_addresses, get_w3_connection
 
@@ -103,7 +104,7 @@ class BaseClient:
             raise Exception(result_code["error"])
         return True
 
-    def deposit_to_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address):
+    def deposit_to_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> TxResult:
         """Deposit funds via socket superbridge to Derive chain smart contract funding account.
 
         Parameters:
@@ -121,14 +122,14 @@ class BaseClient:
         client = BridgeClient(self.env, w3=w3, account=self.signer, chain_id=chain_id)
         client.load_bridge_contract(token_data.Vault, token_data.isNewBridge)
         client.load_deposit_helper()
-        client.deposit(
+        return client.deposit(
             amount=amount,
             receiver=receiver,
             connector=connector,
             token_data=token_data,
         )
 
-    def withdraw_from_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address):
+    def withdraw_from_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> TxResult:
         """Deposit funds via socket superbridge to Derive chain smart contract funding account.
 
         Parameters:
@@ -144,7 +145,7 @@ class BaseClient:
         amount = int(amount * 10 ** TOKEN_DECIMALS[UnderlyingCurrency(currency.name.lower())])
         client = BridgeClient(self.env, w3=w3, account=self.signer, chain_id=chain_id)
         client.load_withdraw_wrapper()
-        client.withdraw_with_wrapper(
+        return client.withdraw_with_wrapper(
             amount=amount,
             receiver=receiver,
             token_data=token_data,

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -26,6 +26,7 @@ from derive_client._bridge import BridgeClient
 from derive_client.constants import CONFIGS, DEFAULT_REFERER, PUBLIC_HEADERS, TARGET_SPEED, TOKEN_DECIMALS
 from derive_client.data_types import (
     Address,
+    BridgeResult,
     ChainID,
     CollateralAsset,
     CreateSubAccountData,
@@ -40,8 +41,6 @@ from derive_client.data_types import (
     SubaccountType,
     TimeInForce,
     UnderlyingCurrency,
-    TxResult,
-    BridgeResult,
 )
 from derive_client.utils import get_logger, get_prod_derive_addresses, get_w3_connection
 
@@ -140,7 +139,9 @@ class BaseClient:
             tx_result=tx_result,
         )
 
-    def withdraw_from_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> BridgeResult:
+    def withdraw_from_derive(
+        self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address
+    ) -> BridgeResult:
         """Deposit funds via socket superbridge to Derive chain smart contract funding account.
 
         Parameters:

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -41,6 +41,7 @@ from derive_client.data_types import (
     TimeInForce,
     UnderlyingCurrency,
     TxResult,
+    BridgeResult,
 )
 from derive_client.utils import get_logger, get_prod_derive_addresses, get_w3_connection
 
@@ -104,7 +105,7 @@ class BaseClient:
             raise Exception(result_code["error"])
         return True
 
-    def deposit_to_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> TxResult:
+    def deposit_to_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> BridgeResult:
         """Deposit funds via socket superbridge to Derive chain smart contract funding account.
 
         Parameters:
@@ -122,14 +123,24 @@ class BaseClient:
         client = BridgeClient(self.env, w3=w3, account=self.signer, chain_id=chain_id)
         client.load_bridge_contract(token_data.Vault, token_data.isNewBridge)
         client.load_deposit_helper()
-        return client.deposit(
+        tx_result = client.deposit(
             amount=amount,
             receiver=receiver,
             connector=connector,
             token_data=token_data,
         )
 
-    def withdraw_from_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> TxResult:
+        return BridgeResult(
+            source_chain=chain_id,
+            target_chain=ChainID.DERIVE,
+            source_token=currency,
+            target_token=currency,
+            amount=amount,
+            receiver=receiver,
+            tx_result=tx_result,
+        )
+
+    def withdraw_from_derive(self, chain_id: ChainID, currency: Currency, amount: int, receiver: Address) -> BridgeResult:
         """Deposit funds via socket superbridge to Derive chain smart contract funding account.
 
         Parameters:
@@ -145,12 +156,22 @@ class BaseClient:
         amount = int(amount * 10 ** TOKEN_DECIMALS[UnderlyingCurrency(currency.name.lower())])
         client = BridgeClient(self.env, w3=w3, account=self.signer, chain_id=chain_id)
         client.load_withdraw_wrapper()
-        return client.withdraw_with_wrapper(
+        tx_result = client.withdraw_with_wrapper(
             amount=amount,
             receiver=receiver,
             token_data=token_data,
             wallet=self.wallet,
             private_key=self.signer._private_key,
+        )
+
+        return BridgeResult(
+            source_chain=ChainID.DERIVE,
+            target_chain=chain_id,
+            source_token=currency,
+            target_token=currency,
+            amount=amount,
+            receiver=receiver,
+            tx_result=tx_result,
         )
 
     def fetch_instruments(

--- a/derive_client/data_types/__init__.py
+++ b/derive_client/data_types/__init__.py
@@ -24,10 +24,12 @@ from .models import (
     DeriveAddresses,
     MintableTokenData,
     NonMintableTokenData,
+    TxResult,
 )
 
 __all__ = [
     "TxStatus",
+    "TxResult",
     "ChainID",
     "Currency",
     "RPCEndPoints",

--- a/derive_client/data_types/__init__.py
+++ b/derive_client/data_types/__init__.py
@@ -19,13 +19,13 @@ from .enums import (
 )
 from .models import (
     Address,
+    BridgeResult,
     CreateSubAccountData,
     CreateSubAccountDetails,
     DeriveAddresses,
     MintableTokenData,
     NonMintableTokenData,
     TxResult,
-    BridgeResult,
 )
 
 __all__ = [

--- a/derive_client/data_types/__init__.py
+++ b/derive_client/data_types/__init__.py
@@ -25,11 +25,13 @@ from .models import (
     MintableTokenData,
     NonMintableTokenData,
     TxResult,
+    BridgeResult,
 )
 
 __all__ = [
     "TxStatus",
     "TxResult",
+    "BridgeResult",
     "ChainID",
     "Currency",
     "RPCEndPoints",

--- a/derive_client/data_types/enums.py
+++ b/derive_client/data_types/enums.py
@@ -4,10 +4,10 @@ from enum import Enum, IntEnum
 
 
 class TxStatus(IntEnum):
-    FAILED = 0   # confirmed and status == 0 (on-chain revert)
+    FAILED = 0  # confirmed and status == 0 (on-chain revert)
     SUCCESS = 1  # confirmed and status == 1
     PENDING = 2  # not yet confirmed, no receipt
-    ERROR = 3    # local error, e.g. connection, invalid tx
+    ERROR = 3  # local error, e.g. connection, invalid tx
 
 
 class ChainID(IntEnum):

--- a/derive_client/data_types/enums.py
+++ b/derive_client/data_types/enums.py
@@ -4,8 +4,10 @@ from enum import Enum, IntEnum
 
 
 class TxStatus(IntEnum):
-    FAILED = 0
-    SUCCESS = 1
+    FAILED = 0   # confirmed and status == 0 (on-chain revert)
+    SUCCESS = 1  # confirmed and status == 1
+    PENDING = 2  # not yet confirmed, no receipt
+    ERROR = 3    # local error, e.g. connection, invalid tx
 
 
 class ChainID(IntEnum):

--- a/derive_client/data_types/models.py
+++ b/derive_client/data_types/models.py
@@ -85,3 +85,13 @@ class TxResult(BaseModel):
     @property
     def is_failed(self) -> bool:
         return self.exception is not None and not self.is_timed_out()
+
+
+class BridgeResult(BaseModel):
+    source_chain: ChainID
+    target_chain: ChainID
+    source_token: Currency
+    target_token: Currency
+    amount: int
+    receiver: Address
+    tx_result: TxResult

--- a/derive_client/data_types/models.py
+++ b/derive_client/data_types/models.py
@@ -10,7 +10,8 @@ from pydantic import BaseModel, ConfigDict
 from web3 import Web3
 from web3.datastructures import AttributeDict
 
-from .enums import ChainID, Currency
+from .enums import ChainID, Currency, TxStatus
+
 
 Address = str
 
@@ -69,25 +70,23 @@ class DeriveAddresses(BaseModel):
     chains: dict[ChainID, dict[Currency, MintableTokenData | NonMintableTokenData]]
 
 
-class TxResult(BaseModel):
+@dataclass
+class TxResult:
     tx_hash: str
-    receipt: AttributeDict | None
+    tx_receipt: AttributeDict | None
     exception: Exception | None
 
     @property
-    def is_pending(self) -> bool:
-        return self.receipt is None and self.exception is None
-
-    @property
-    def is_timed_out(self) -> bool:
-        return isinstance(self.exception, TimeoutError)
-
-    @property
-    def is_failed(self) -> bool:
-        return self.exception is not None and not self.is_timed_out()
+    def status(self) -> TxStatus:
+        if self.tx_receipt is not None:
+            return TxStatus(int(self.tx_receipt.status))  # ∈ {0, 1} (EIP-658)
+        if isinstance(self.exception, TimeoutError):
+            return TxStatus.PENDING
+        return TxStatus.ERROR
 
 
-class BridgeResult(BaseModel):
+@dataclass
+class BridgeResult:
     source_chain: ChainID
     target_chain: ChainID
     source_token: Currency

--- a/derive_client/data_types/models.py
+++ b/derive_client/data_types/models.py
@@ -12,7 +12,6 @@ from web3.datastructures import AttributeDict
 
 from .enums import ChainID, Currency, TxStatus
 
-
 Address = str
 
 

--- a/derive_client/utils.py
+++ b/derive_client/utils.py
@@ -9,14 +9,14 @@ import sys
 import time
 from collections import defaultdict
 
-from rich.logging import RichHandler
 from hexbytes import HexBytes
+from rich.logging import RichHandler
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
 
 from derive_client.constants import ABI_DATA_DIR, DATA_DIR
-from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints, TxStatus, TxResult
+from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints, TxResult, TxStatus
 
 
 def get_logger():
@@ -105,11 +105,7 @@ def sign_and_send_tx(w3: Web3, tx: dict, private_key: str) -> HexBytes:
 
 
 def send_and_confirm_tx(
-    w3: Web3,
-    tx: dict,
-    private_key: str,
-    *,
-    action: str  # e.g. "approve()", "deposit()", "withdraw()"
+    w3: Web3, tx: dict, private_key: str, *, action: str  # e.g. "approve()", "deposit()", "withdraw()"
 ) -> TxResult:
     tx_result = TxResult(tx_hash="", tx_receipt=None, exception=None)
 

--- a/derive_client/utils.py
+++ b/derive_client/utils.py
@@ -16,7 +16,7 @@ from web3.contract import Contract
 from web3.datastructures import AttributeDict
 
 from derive_client.constants import ABI_DATA_DIR, DATA_DIR
-from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints, TxResult
+from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints, TxStatus, TxResult
 
 
 def get_logger():
@@ -111,7 +111,7 @@ def send_and_confirm_tx(
     *,
     action: str  # e.g. "approve()", "deposit()", "withdraw()"
 ) -> TxResult:
-    tx_result = TxResult(tx_hash="", receipt=None, exception=None)
+    tx_result = TxResult(tx_hash="", tx_receipt=None, exception=None)
 
     try:
         tx_hash = sign_and_send_tx(w3=w3, tx=tx, private_key=private_key)

--- a/derive_client/utils.py
+++ b/derive_client/utils.py
@@ -16,7 +16,7 @@ from web3.contract import Contract
 from web3.datastructures import AttributeDict
 
 from derive_client.constants import ABI_DATA_DIR, DATA_DIR
-from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints
+from derive_client.data_types import ChainID, DeriveAddresses, RPCEndPoints, TxResult
 
 
 def get_logger():
@@ -102,6 +102,43 @@ def sign_and_send_tx(w3: Web3, tx: dict, private_key: str) -> HexBytes:
     tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
     print(f"tx_hash: 0x{tx_hash.hex()}")
     return tx_hash
+
+
+def send_and_confirm_tx(
+    w3: Web3,
+    tx: dict,
+    private_key: str,
+    *,
+    action: str  # e.g. "approve()", "deposit()", "withdraw()"
+) -> TxResult:
+    tx_result = TxResult(tx_hash="", receipt=None, exception=None)
+
+    try:
+        tx_hash = sign_and_send_tx(w3=w3, tx=tx, private_key=private_key)
+        tx_result.tx_hash = tx_hash.hex()
+    except Exception as send_err:
+        print(f"❌ Failed to send tx for {action}, error: {send_err!r}")
+        tx_result.exception = send_err
+        return tx_result
+
+    try:
+        tx_receipt = wait_for_tx_receipt(w3=w3, tx_hash=tx_hash)
+        tx_result.tx_receipt = tx_receipt
+    except TimeoutError as timeout_err:
+        print(f"⏱️  Timeout waiting for tx receipt of {tx_hash.hex()}")
+        tx_result.exception = timeout_err
+        return tx_result
+    except Exception as wait_err:
+        print(f"⚠️  Error while waiting for tx receipt of {tx_hash.hex()}: {wait_err!r}")
+        tx_result.exception = wait_err
+        return tx_result
+
+    if tx_receipt.status == TxStatus.SUCCESS:
+        print(f"✅ {action} succeeded for tx {tx_hash.hex()}")
+    else:
+        print(f"❌ {action} reverted for tx {tx_hash.hex()}")
+
+    return tx_result
 
 
 def estimate_fees(w3, percentiles: list[int], blocks=20, default_tip=10_000):

--- a/derive_client/utils.py
+++ b/derive_client/utils.py
@@ -10,6 +10,7 @@ import time
 from collections import defaultdict
 
 from rich.logging import RichHandler
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 from web3.datastructures import AttributeDict
@@ -95,14 +96,12 @@ def wait_for_tx_receipt(w3: Web3, tx_hash: str, timeout=120, poll_interval=1) ->
         time.sleep(poll_interval)
 
 
-def sign_and_send_tx(w3: Web3, tx: dict, private_key: str) -> AttributeDict:
+def sign_and_send_tx(w3: Web3, tx: dict, private_key: str) -> HexBytes:
     signed_tx = w3.eth.account.sign_transaction(tx, private_key=private_key)
     print(f"signed_tx: {signed_tx}")
     tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
     print(f"tx_hash: 0x{tx_hash.hex()}")
-    receipt = wait_for_tx_receipt(w3, tx_hash)
-    print(f"tx_receipt: {receipt}")
-    return receipt
+    return tx_hash
 
 
 def estimate_fees(w3, percentiles: list[int], blocks=20, default_tip=10_000):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ skip_gitignore = true
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py310']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
This PR introduces `TxResult` and `BridgeResult` to provide structured feedback for deposit and withdrawal operations to the caller
- `TxResult` encapsulates transaction status and relevant transaction data.
- `BridgeResult` wraps the `TxResult` and context (source and target chain, token, plus receiver and amount).

We could expose a method for clients to provide their `BridgeResult` to for a status update in case `TxResult.status` is `TxStatus.PENDING`. It contains all the necessary information for the Derive client to do so and removes the need for the caller (i.e. `AssetBridgingInterface`) to instantiate their own w3 instance and provide a correct RPC URL