### PR TITLE
Remove and replace print statements with logger

### DIFF
--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -445,7 +445,7 @@ class BridgeClient:
             raise BridgeEventParseError(f"Could not decode LayerZero OFTSent guid: {e}") from e
 
         tx_result.event_id = guid.hex()
-        print(f"🔖 Source [{tx_result.source_chain.name}] OFTSent GUID: {tx_result.event_id}")
+        self.logger.info(f"🔖 Source [{tx_result.source_chain.name}] OFTSent GUID: {tx_result.event_id}")
 
         filter_params = make_filter_params(
             event=context.target_event,
@@ -453,7 +453,7 @@ class BridgeClient:
             argument_filters={"guid": guid},
         )
 
-        print(f"🔍 Listening for OFTReceived on [{tx_result.target_chain.name}] at {context.target_event.address}")
+        self.logger.info(f"🔍 Listening for OFTReceived on [{tx_result.target_chain.name}] at {context.target_event.address}")
         return wait_for_event(context.target_w3, filter_params)
 
     def fetch_socket_event_log(self, tx_result: BridgeTxResult, context: BridgeContext):
@@ -465,7 +465,7 @@ class BridgeClient:
             raise BridgeEventParseError(f"Could not decode Socket MessageOutbound event: {e}") from e
 
         tx_result.event_id = message_id.hex()
-        print(f"🔖 Source [{tx_result.source_chain.name}] MessageOutbound msgId: {tx_result.event_id}")
+        self.logger.info(f"🔖 Source [{tx_result.source_chain.name}] MessageOutbound msgId: {tx_result.event_id}")
         filter_params = context.target_event._get_event_filter_params(
             fromBlock=tx_result.target_from_block, abi=context.target_event.abi
         )
@@ -474,7 +474,7 @@ class BridgeClient:
             decoded = context.target_event.process_log(log)
             return decoded.get("args", {}).get("msgId") == message_id
 
-        print(f"🔍 Listening for ExecutionSuccess on [{tx_result.target_chain.name}] at {context.target_event.address}")
+        self.logger.info(f"🔍 Listening for ExecutionSuccess on [{tx_result.target_chain.name}] at {context.target_event.address}")
         return wait_for_event(context.target_w3, filter_params, condition=matching_message_id)
 
     def poll_bridge_progress(self, tx_result: BridgeTxResult) -> BridgeTxResult:
@@ -500,7 +500,7 @@ class BridgeClient:
 
         # 1. TimeoutError as exception during source_tx.tx_receipt
         if not tx_result.source_tx.tx_receipt:
-            print(
+            self.logger.info(
                 f"⏳ Checking source chain [{tx_result.source_chain.name}] tx receipt for {tx_result.source_tx.tx_hash}"
             )
             tx_result.source_tx.exception = None
@@ -522,7 +522,7 @@ class BridgeClient:
 
         # 3. Timeout waiting for target_tx.tx_receipt
         if not tx_result.target_tx.tx_receipt:
-            print(
+            self.logger.info(
                 f"⏳ Checking target chain [{tx_result.target_chain.name}] tx receipt for {tx_result.target_tx.tx_hash}"
             )
             tx_result.target_tx.exception = None
@@ -539,7 +539,7 @@ class BridgeClient:
         """Ensure that the Derive EOA wallet has sufficient ETH balance for gas."""
         balance_of_owner = self.derive_w3.eth.get_balance(self.owner)
         if balance_of_owner < DEPOSIT_GAS_LIMIT:
-            print(f"Funding Derive EOA wallet with {DEFAULT_GAS_FUNDING_AMOUNT} ETH")
+            self.logger.info(f"Funding Derive EOA wallet with {DEFAULT_GAS_FUNDING_AMOUNT} ETH")
             self.bridge_mainnet_eth_to_derive(DEFAULT_GAS_FUNDING_AMOUNT)
 
     def bridge_mainnet_eth_to_derive(self, amount: int) -> TxResult:

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -269,7 +269,9 @@ class BridgeClient:
         else:
             tx = self._prepare_old_style_deposit(token_data, amount)
 
-        source_tx = send_and_confirm_tx(w3=context.source_w3, tx=tx, private_key=self.private_key, action="bridge()", logger=self.logger)
+        source_tx = send_and_confirm_tx(
+            w3=context.source_w3, tx=tx, private_key=self.private_key, action="bridge()", logger=self.logger
+        )
         tx_result = BridgeTxResult(
             currency=currency,
             bridge=BridgeType.SOCKET,
@@ -319,7 +321,11 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=0)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
+            w3=context.source_w3,
+            tx=tx,
+            private_key=self.private_key,
+            action="executeBatch()",
+            logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -377,7 +383,11 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=native_fee)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
+            w3=context.source_w3,
+            tx=tx,
+            private_key=self.private_key,
+            action="executeBatch()",
+            logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -425,7 +435,11 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=0)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
+            w3=context.source_w3,
+            tx=tx,
+            private_key=self.private_key,
+            action="executeBatch()",
+            logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -455,7 +469,9 @@ class BridgeClient:
             argument_filters={"guid": guid},
         )
 
-        self.logger.info(f"🔍 Listening for OFTReceived on [{tx_result.target_chain.name}] at {context.target_event.address}")
+        self.logger.info(
+            f"🔍 Listening for OFTReceived on [{tx_result.target_chain.name}] at {context.target_event.address}"
+        )
         return wait_for_event(context.target_w3, filter_params, logger=self.logger)
 
     def fetch_socket_event_log(self, tx_result: BridgeTxResult, context: BridgeContext):
@@ -476,7 +492,9 @@ class BridgeClient:
             decoded = context.target_event.process_log(log)
             return decoded.get("args", {}).get("msgId") == message_id
 
-        self.logger.info(f"🔍 Listening for ExecutionSuccess on [{tx_result.target_chain.name}] at {context.target_event.address}")
+        self.logger.info(
+            f"🔍 Listening for ExecutionSuccess on [{tx_result.target_chain.name}] at {context.target_event.address}"
+        )
         return wait_for_event(context.target_w3, filter_params, condition=matching_message_id, logger=self.logger)
 
     def poll_bridge_progress(self, tx_result: BridgeTxResult) -> BridgeTxResult:
@@ -557,7 +575,9 @@ class BridgeClient:
         proxy_contract = get_contract(w3=w3, address=address, abi=bridge_abi)
 
         tx = prepare_mainnet_to_derive_gas_tx(w3=w3, account=self.account, amount=amount, proxy_contract=proxy_contract)
-        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.private_key, action="bridgeETH()", logger=self.logger)
+        tx_result = send_and_confirm_tx(
+            w3=w3, tx=tx, private_key=self.private_key, action="bridgeETH()", logger=self.logger
+        )
         return tx_result
 
     def _prepare_new_style_deposit(self, token_data: NonMintableTokenData, amount: int) -> dict:

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -269,7 +269,7 @@ class BridgeClient:
         else:
             tx = self._prepare_old_style_deposit(token_data, amount)
 
-        source_tx = send_and_confirm_tx(w3=context.source_w3, tx=tx, private_key=self.private_key, action="bridge()")
+        source_tx = send_and_confirm_tx(w3=context.source_w3, tx=tx, private_key=self.private_key, action="bridge()", logger=self.logger)
         tx_result = BridgeTxResult(
             currency=currency,
             bridge=BridgeType.SOCKET,
@@ -319,7 +319,7 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=0)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()"
+            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -377,7 +377,7 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=native_fee)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()"
+            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -425,7 +425,7 @@ class BridgeClient:
         tx = build_standard_transaction(func=func, account=self.account, w3=context.source_w3, value=0)
 
         source_tx = send_and_confirm_tx(
-            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()"
+            w3=context.source_w3, tx=tx, private_key=self.private_key, action="executeBatch()", logger=self.logger,
         )
         tx_result = BridgeTxResult(
             currency=currency,
@@ -557,7 +557,7 @@ class BridgeClient:
         proxy_contract = get_contract(w3=w3, address=address, abi=bridge_abi)
 
         tx = prepare_mainnet_to_derive_gas_tx(w3=w3, account=self.account, amount=amount, proxy_contract=proxy_contract)
-        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.private_key, action="bridgeETH()")
+        tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=self.private_key, action="bridgeETH()", logger=self.logger)
         return tx_result
 
     def _prepare_new_style_deposit(self, token_data: NonMintableTokenData, amount: int) -> dict:

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -261,6 +261,7 @@ class BridgeClient:
             spender=spender,
             amount=amount,
             private_key=self.private_key,
+            logger=self.logger,
         )
 
         if token_data.isNewBridge:
@@ -350,6 +351,7 @@ class BridgeClient:
             spender=context.source_token.address,
             amount=amount,
             private_key=self.private_key,
+            logger=self.logger,
         )
 
         # build the send tx

--- a/derive_client/_bridge/client.py
+++ b/derive_client/_bridge/client.py
@@ -456,7 +456,7 @@ class BridgeClient:
         )
 
         self.logger.info(f"🔍 Listening for OFTReceived on [{tx_result.target_chain.name}] at {context.target_event.address}")
-        return wait_for_event(context.target_w3, filter_params)
+        return wait_for_event(context.target_w3, filter_params, logger=self.logger)
 
     def fetch_socket_event_log(self, tx_result: BridgeTxResult, context: BridgeContext):
 
@@ -477,7 +477,7 @@ class BridgeClient:
             return decoded.get("args", {}).get("msgId") == message_id
 
         self.logger.info(f"🔍 Listening for ExecutionSuccess on [{tx_result.target_chain.name}] at {context.target_event.address}")
-        return wait_for_event(context.target_w3, filter_params, condition=matching_message_id)
+        return wait_for_event(context.target_w3, filter_params, condition=matching_message_id, logger=self.logger)
 
     def poll_bridge_progress(self, tx_result: BridgeTxResult) -> BridgeTxResult:
         if tx_result.status is not TxStatus.PENDING:

--- a/derive_client/_bridge/transaction.py
+++ b/derive_client/_bridge/transaction.py
@@ -1,3 +1,5 @@
+from logging import Logger
+
 from eth_account import Account
 from web3 import Web3
 from web3.contract import Contract
@@ -30,10 +32,11 @@ def ensure_allowance(
     spender: Address,
     amount: int,
     private_key: str,
+    logger: Logger,
 ):
     allowance = token_contract.functions.allowance(owner, spender).call()
     if amount > allowance:
-        print(f"Increasing allowance from {allowance} to {amount}")
+        logger.info(f"Increasing allowance from {allowance} to {amount}")
         increase_allowance(
             w3=w3,
             from_account=Account.from_key(private_key),

--- a/derive_client/_bridge/transaction.py
+++ b/derive_client/_bridge/transaction.py
@@ -44,6 +44,7 @@ def ensure_allowance(
             spender=spender,
             amount=amount,
             private_key=private_key,
+            logger=logger,
         )
 
 
@@ -54,10 +55,11 @@ def increase_allowance(
     spender: Address,
     amount: int,
     private_key: str,
+    logger: Logger,
 ) -> None:
     func = erc20_contract.functions.approve(spender, amount)
     tx = build_standard_transaction(func=func, account=from_account, w3=w3)
-    tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=private_key, action="approve()")
+    tx_result = send_and_confirm_tx(w3=w3, tx=tx, private_key=private_key, action="approve()", logger=logger)
     if tx_result.status != TxStatus.SUCCESS:
         raise RuntimeError("approve() failed")
 

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -21,7 +21,6 @@ from derive_action_signing.module_data import (
 from derive_action_signing.signed_action import SignedAction
 from derive_action_signing.utils import MAX_INT_32, get_action_nonce, sign_rest_auth_header, sign_ws_login, utc_now_ms
 from pydantic import validate_call
-from rich import print
 from web3 import Web3
 from websocket import WebSocketConnectionClosedException, create_connection
 

--- a/derive_client/utils/retry.py
+++ b/derive_client/utils/retry.py
@@ -23,31 +23,13 @@ RETRY_EXCEPTIONS = (
 )
 
 
-def retry(
-    fn: Callable[..., T],
-    *args,
-    retries: int = 3,
-    delay: float = 1.0,
-    exception: Exception = Exception,
-    **kwargs,
+def exp_backoff_retry(
+    func: Callable[..., T] | None = None,
+    *,
+    attempts: int = 3,
+    initial_delay: float = 1.0,
+    exceptions=(Exception,)
 ) -> T:
-    """Call fn(*args, **kwargs), retrying up to `retries` times on `exception`, with `delay` seconds."""
-    last_exc: Exception | None = None
-    for attempt in range(1, retries + 1):
-        try:
-            return fn(*args, **kwargs)
-        except exception as e:
-            last_exc = e
-            if attempt < retries:
-                time.sleep(delay)
-            else:
-                raise
-    # mypy guard
-    assert last_exc is not None
-    raise last_exc
-
-
-def exp_backoff_retry(func=None, *, attempts=3, initial_delay=1, exceptions=(Exception,)):
     if func is None:
         return lambda f: exp_backoff_retry(f, attempts=attempts, initial_delay=initial_delay, exceptions=exceptions)
 

--- a/derive_client/utils/retry.py
+++ b/derive_client/utils/retry.py
@@ -28,7 +28,7 @@ def exp_backoff_retry(
     *,
     attempts: int = 3,
     initial_delay: float = 1.0,
-    exceptions=(Exception,)
+    exceptions=(Exception,),
 ) -> T:
     if func is None:
         return lambda f: exp_backoff_retry(f, attempts=attempts, initial_delay=initial_delay, exceptions=exceptions)
@@ -41,8 +41,7 @@ def exp_backoff_retry(
                 return func(*args, **kwargs)
             except exceptions as e:
                 if attempt == attempts - 1:
-                    raise
-                print(f"Failed execution:\n{e}\nTrying again in {delay} seconds")
+                    raise e
                 time.sleep(delay)
                 delay *= 2
 

--- a/derive_client/utils/w3.py
+++ b/derive_client/utils/w3.py
@@ -259,14 +259,14 @@ def send_and_confirm_tx(
         tx_receipt = wait_for_tx_receipt(w3=w3, tx_hash=tx_hash)
         tx_result.tx_receipt = tx_receipt
     except TimeoutError as timeout_err:
-        logger.warning(f"⏱️ Timeout waiting for tx receipt of {tx_hash.hex()}")
+        logger.warning(f"⏱️ Timeout waiting for tx receipt of {tx_hash.to_0x_hex()}")
         tx_result.exception = timeout_err
         return tx_result
 
     if tx_result.tx_receipt.status == TxStatus.SUCCESS:
-        logger.info(f"✅ {action} succeeded for tx {tx_hash.hex()}")
+        logger.info(f"✅ {action} succeeded for tx {tx_hash.to_0x_hex()}")
     else:
-        logger.error(f"❌ {action} reverted for tx {tx_hash.hex()}")
+        logger.error(f"❌ {action} reverted for tx {tx_hash.to_0x_hex()}")
 
     return tx_result
 

--- a/derive_client/utils/w3.py
+++ b/derive_client/utils/w3.py
@@ -306,6 +306,7 @@ def iter_events(
     max_block_range: int = 10_000,
     poll_interval: float = 5.0,
     timeout: float | None = None,
+    logger: Logger,
 ) -> Generator[AttributeDict, None, None]:
     """Stream matching logs over a fixed or live block window. Optionally raises TimeoutError."""
 
@@ -321,6 +322,7 @@ def iter_events(
     while True:
         if deadline and time.time() > deadline:
             msg = f"Timed out waiting for events after scanning blocks {start_block}-{cursor}"
+            logger.warning(msg)
             raise TimeoutError(f"{msg}: filter_params: {original_filter_params}")
         upper = fixed_ceiling or w3.eth.block_number
         if cursor <= upper:
@@ -333,7 +335,7 @@ def iter_events(
                 filter_params=filter_params,
                 retries=EVENT_LOG_RETRIES,
             )
-            print(f"Scanned {cursor} - {end}: {len(logs)} logs")
+            logger.info(f"Scanned {cursor} - {end}: {len(logs)} logs")
             yield from filter(condition, logs)
             cursor = end + 1  # bounds are inclusive
 
@@ -351,6 +353,7 @@ def wait_for_event(
     max_block_range: int = 10_000,
     poll_interval: float = 5.0,
     timeout: float = 300.0,
+    logger: Logger,
 ) -> AttributeDict:
     """Return the first log from iter_events, or raise TimeoutError after `timeout` seconds."""
 


### PR DESCRIPTION
- replaces all print statements in the client with logging
- refactors to remove the  "retry" helper introduced in PR #60 and instead reuses the existing `exp_backoff_retry`