### PR TITLE
Remove and replace websocket usage from BaseClient

### DIFF
--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -377,14 +377,6 @@ class BaseClient:
         )
         return self.web3_client.keccak(encoded_data)
 
-    @property
-    def ws(self):
-        if not hasattr(self, "_ws"):
-            self._ws = self.connect_ws()
-        if not self._ws.connected:
-            self._ws = self.connect_ws()
-        return self._ws
-
     def fetch_ticker(self, instrument_name):
         """
         Fetch the ticker for a given instrument name.

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -454,22 +454,18 @@ class BaseClient:
         results = response.json()["result"]["orders"]
         return results
 
+
     def cancel(self, order_id, instrument_name):
         """
         Cancel an order
         """
-
-        id = str(utc_now_ms())
+        url = self.endpoints.private.cancel
         payload = {
             "order_id": order_id,
             "subaccount_id": self.subaccount_id,
             "instrument_name": instrument_name,
         }
-        self.ws.send(json.dumps({"method": "private/cancel", "params": payload, "id": id}))
-        while True:
-            message = json.loads(self.ws.recv())
-            if message["id"] == id:
-                return message["result"]
+        return self._send_request(url, json=payload)
 
     def cancel_all(self):
         """

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -331,19 +331,8 @@ class BaseClient:
         return action
 
     def submit_order(self, order):
-        id = str(utc_now_ms())
-        self.ws.send(json.dumps({"method": "private/order", "params": order, "id": id}))
-        while True:
-            message = json.loads(self.ws.recv())
-            if message["id"] == id:
-                try:
-                    if "result" not in message:
-                        if self._check_output_for_rate_limit(message):
-                            return self.submit_order(order)
-                        raise DeriveJSONRPCException(**message["error"])
-                    return message["result"]["order"]
-                except KeyError as error:
-                    raise Exception(f"Unable to submit order {message}") from error
+        url = self.endpoints.private.order
+        return self._send_request(url, json=order)["order"]
 
     def _sign_quote(self, quote):
         """

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -471,18 +471,9 @@ class BaseClient:
         """
         Cancel all orders
         """
-        id = str(utc_now_ms())
+        url = self.endpoints.private.cancel_all
         payload = {"subaccount_id": self.subaccount_id}
-        self.login_client()
-        self.ws.send(json.dumps({"method": "private/cancel_all", "params": payload, "id": id}))
-        while True:
-            message = json.loads(self.ws.recv())
-            if message["id"] == id:
-                if "result" not in message:
-                    if self._check_output_for_rate_limit(message):
-                        return self.cancel_all()
-                    raise DeriveJSONRPCException(**message["error"])
-                return message["result"]
+        return self._send_request(url, json=payload)
 
     def _check_output_for_rate_limit(self, message):
         if error := message.get("error"):

--- a/derive_client/clients/ws_client.py
+++ b/derive_client/clients/ws_client.py
@@ -32,3 +32,20 @@ class WsClient(BaseClient):
                     return message["result"]["order"]
                 except KeyError as error:
                     raise Exception(f"Unable to submit order {message}") from error
+
+    def cancel(self, order_id, instrument_name):
+        """
+        Cancel an order
+        """
+
+        id = str(utc_now_ms())
+        payload = {
+            "order_id": order_id,
+            "subaccount_id": self.subaccount_id,
+            "instrument_name": instrument_name,
+        }
+        self.ws.send(json.dumps({"method": "private/cancel", "params": payload, "id": id}))
+        while True:
+            message = json.loads(self.ws.recv())
+            if message["id"] == id:
+                return message["result"]

--- a/derive_client/derive.py
+++ b/derive_client/derive.py
@@ -24,4 +24,3 @@ class DeriveClient(BaseClient):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.login_client()

--- a/derive_client/endpoints.py
+++ b/derive_client/endpoints.py
@@ -48,6 +48,7 @@ class PrivateEndpoints:
     withdraw = Endpoint("private", "withdraw")
     order = Endpoint("private", "order")
     cancel = Endpoint("private", "cancel")
+    cancel_all = Endpoint("private", "cancel_all")
 
 
 class RestAPI:

--- a/derive_client/endpoints.py
+++ b/derive_client/endpoints.py
@@ -47,6 +47,7 @@ class PrivateEndpoints:
     deposit = Endpoint("private", "deposit")
     withdraw = Endpoint("private", "withdraw")
     order = Endpoint("private", "order")
+    cancel = Endpoint("private", "cancel")
 
 
 class RestAPI:

--- a/derive_client/endpoints.py
+++ b/derive_client/endpoints.py
@@ -46,6 +46,7 @@ class PrivateEndpoints:
     send_quote = Endpoint("private", "send_quote")
     deposit = Endpoint("private", "deposit")
     withdraw = Endpoint("private", "withdraw")
+    order = Endpoint("private", "order")
 
 
 class RestAPI:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -225,7 +225,6 @@ def test_get_collaterals(derive_client):
     assert isinstance(collaterals, list)
 
 
-@pytest.mark.skip("This test is not working on testnet due to rate limiting")
 def test_get_tickers(derive_client):
     """Test get tickers."""
     tickers = derive_client.fetch_tickers()


### PR DESCRIPTION
Remove any and all websocket usage / reference from `BaseClient`, which now uses the REST API only. The existing functionality has been moved to the `WebsocketClient`