### PR TITLE
feat/sim txns

### DIFF
--- a/.github/workflows/common_check.yaml
+++ b/.github/workflows/common_check.yaml
@@ -46,6 +46,10 @@ jobs:
         run: |
           poetry run make lint
 
+      - name: Ensure Certifi CA bundle is used
+        run: |
+          echo "REQUESTS_CA_BUNDLE=$(python -c 'import certifi; print(certifi.where())')" >> $GITHUB_ENV
+
       - name: Tests
         run: |
           poetry run make tests

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean-test:
 
 .PHONY: tests
 tests:
-	poetry run pytest tests -vv  --reruns 10 --reruns-delay 30
+	poetry run pytest tests -vv
 
 fmt:
 	poetry run black tests derive_client examples

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -377,14 +377,6 @@ class BaseClient:
         )
         return self.web3_client.keccak(encoded_data)
 
-    @property
-    def ws(self):
-        if not hasattr(self, "_ws"):
-            self._ws = self.connect_ws()
-        if not self._ws.connected:
-            self._ws = self.connect_ws()
-        return self._ws
-
     def fetch_ticker(self, instrument_name):
         """
         Fetch the ticker for a given instrument name.

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -2,7 +2,9 @@
 Base Client for the derive dex.
 """
 
+import re
 import json
+import time
 import random
 from decimal import Decimal
 from logging import Logger
@@ -51,6 +53,7 @@ from derive_client.data_types import (
     TimeInForce,
     UnderlyingCurrency,
     WithdrawResult,
+    DeriveJSONRPCErrorCode,
 )
 from derive_client.endpoints import RestAPI
 from derive_client.exceptions import DeriveJSONRPCException
@@ -676,14 +679,29 @@ class BaseClient:
             "signature": "filled_in_below",
         }
 
-    def _send_request(self, url, json=None, params=None, headers=None):
+    def _send_request(self, url, json=None, params=None, headers=None, max_retries: int = 5):
         headers = self._create_signature_headers() if not headers else headers
-        response = requests.post(url, json=json, headers=headers, params=params)
-        response.raise_for_status()
-        if "error" in response.json():
-            raise DeriveJSONRPCException(**response.json()["error"])
-        results = response.json()["result"]
-        return results
+        attempt = 0
+        while True:
+            attempt += 1
+            response = requests.post(url, json=json, headers=headers, params=params)
+            response.raise_for_status()
+            json_data = response.json()
+            if (error := json_data.get("error")):
+                code = error.get("code", 0)
+                data = error.get("data", "")
+                if code == DeriveJSONRPCErrorCode.RATE_LIMIT_EXCEEDED and attempt < max_retries:
+                    # extract ms from "Retry after 693 ms"
+                    m = re.search(r"(\d+)\s*ms", data, flags=re.IGNORECASE)
+                    delay = (int(m.group(1)) / 1000) if m else 1.0
+                    self.logger.info(f"Rate limit hit ({data}), retry #{attempt} in {delay}s")
+                    time.sleep(delay)
+                    continue
+                else:
+                    self.logger.warning(f"RPC error or retries exhausted at attempt {attempt}: {error}")
+                    raise DeriveJSONRPCException(**error)
+            else:
+                return json_data["result"]
 
     def fetch_all_currencies(self):
         """

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -2,10 +2,10 @@
 Base Client for the derive dex.
 """
 
-import re
 import json
-import time
 import random
+import re
+import time
 from decimal import Decimal
 from logging import Logger
 from time import sleep
@@ -37,6 +37,7 @@ from derive_client.data_types import (
     CreateSubAccountDetails,
     Currency,
     DepositResult,
+    DeriveJSONRPCErrorCode,
     DeriveTxResult,
     DeriveTxStatus,
     Environment,
@@ -53,11 +54,10 @@ from derive_client.data_types import (
     TimeInForce,
     UnderlyingCurrency,
     WithdrawResult,
-    DeriveJSONRPCErrorCode,
 )
 from derive_client.endpoints import RestAPI
 from derive_client.exceptions import DeriveJSONRPCException
-from derive_client.utils import get_logger, wait_until, get_retry_session
+from derive_client.utils import get_logger, get_retry_session, wait_until
 
 
 def _is_final_tx(res: DeriveTxResult) -> bool:
@@ -688,7 +688,7 @@ class BaseClient:
             response = session.post(url, json=json, headers=headers, params=params)
             response.raise_for_status()
             json_data = response.json()
-            if (error := json_data.get("error")):
+            if error := json_data.get("error"):
                 code = error.get("code", 0)
                 data = error.get("data", "")
                 if code == DeriveJSONRPCErrorCode.RATE_LIMIT_EXCEEDED and attempt < max_retries:

--- a/derive_client/clients/base_client.py
+++ b/derive_client/clients/base_client.py
@@ -471,18 +471,9 @@ class BaseClient:
         """
         Cancel all orders
         """
-        id = str(utc_now_ms())
+        url = self.endpoints.private.cancel_all
         payload = {"subaccount_id": self.subaccount_id}
-        self.login_client()
-        self.ws.send(json.dumps({"method": "private/cancel_all", "params": payload, "id": id}))
-        while True:
-            message = json.loads(self.ws.recv())
-            if message["id"] == id:
-                if "result" not in message:
-                    if self._check_output_for_rate_limit(message):
-                        return self.cancel_all()
-                    raise DeriveJSONRPCException(**message["error"])
-                return message["result"]
+        return self._send_request(url, json=payload)
 
     def _check_output_for_rate_limit(self, message):
         if error := message.get("error"):

--- a/derive_client/data_types/models.py
+++ b/derive_client/data_types/models.py
@@ -170,7 +170,7 @@ class BridgeContext:
 
 @dataclass(config=ConfigDict(validate_assignment=True))
 class TxResult:
-    tx_hash: TxHash
+    tx_hash: TxHash | None = None
     tx_receipt: PAttributeDict | None = None
     exception: PException | None = None
 

--- a/derive_client/derive.py
+++ b/derive_client/derive.py
@@ -24,4 +24,3 @@ class DeriveClient(BaseClient):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.login_client()

--- a/derive_client/endpoints.py
+++ b/derive_client/endpoints.py
@@ -48,6 +48,7 @@ class PrivateEndpoints:
     withdraw = Endpoint("private", "withdraw")
     order = Endpoint("private", "order")
     cancel = Endpoint("private", "cancel")
+    cancel_all = Endpoint("private", "cancel_all")
 
 
 class RestAPI:

--- a/derive_client/utils/retry.py
+++ b/derive_client/utils/retry.py
@@ -96,6 +96,7 @@ def wait_until(
     poll_interval=1.0,
     retry_exceptions: type[Exception] | tuple[type[Exception], ...] = (ConnectionError, TimeoutError),
     max_retries: int = 3,
+    timeout_message: str = "",
     **kwargs: P.kwargs,
 ) -> T:
     retries = 0
@@ -112,7 +113,8 @@ def wait_until(
         if result is not None and condition(result):
             return result
         if time.time() - start_time > timeout:
-            raise TimeoutError("Timed out waiting for transaction receipt.")
+            msg = f"Timed out after {timeout}s waiting for condition on {func.__name__} {timeout_message}"
+            raise TimeoutError(msg)
         time.sleep(poll_interval)
 
 

--- a/derive_client/utils/retry.py
+++ b/derive_client/utils/retry.py
@@ -1,6 +1,7 @@
 import functools
 import time
 from http import HTTPStatus
+from logging import Logger
 from typing import Callable, ParamSpec, Sequence, TypeVar
 
 import requests
@@ -62,6 +63,7 @@ def get_retry_session(
         "OPTIONS",
     ),
     raise_on_status: bool = False,
+    logger: Logger | None = None,
 ) -> requests.Session:
     session = requests.Session()
     retry = Retry(
@@ -78,7 +80,7 @@ def get_retry_session(
     session.mount("http://", adapter)
     session.mount("https://", adapter)
 
-    logger = get_logger()
+    logger = logger or get_logger()
 
     def log_response(r, *args, **kwargs):
         logger.info(f"Response {r.request.method} {r.url} (status {r.status_code})")

--- a/derive_client/utils/w3.py
+++ b/derive_client/utils/w3.py
@@ -7,6 +7,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal
 
+import certifi
 import yaml
 from eth_account import Account
 from hexbytes import HexBytes
@@ -142,7 +143,8 @@ def get_w3_connection(
     logger: Logger | None = None,
 ) -> Web3:
     rpc_endpoints = rpc_endpoints or load_rpc_endpoints(DEFAULT_RPC_ENDPOINTS)
-    providers = list(map(HTTPProvider, rpc_endpoints[chain_id]))
+    request_kwargs = {"verify": certifi.where()}
+    providers = [HTTPProvider(url, request_kwargs=request_kwargs) for url in rpc_endpoints[chain_id]]
 
     logger = logger or get_logger()
 

--- a/derive_client/utils/w3.py
+++ b/derive_client/utils/w3.py
@@ -7,7 +7,6 @@ from logging import Logger
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal
 
-import certifi
 import yaml
 from eth_account import Account
 from hexbytes import HexBytes
@@ -143,8 +142,7 @@ def get_w3_connection(
     logger: Logger | None = None,
 ) -> Web3:
     rpc_endpoints = rpc_endpoints or load_rpc_endpoints(DEFAULT_RPC_ENDPOINTS)
-    request_kwargs = {"verify": certifi.where()}
-    providers = [HTTPProvider(url, request_kwargs=request_kwargs) for url in rpc_endpoints[chain_id]]
+    providers = [HTTPProvider(url) for url in rpc_endpoints[chain_id]]
 
     logger = logger or get_logger()
 

--- a/derive_client/utils/w3.py
+++ b/derive_client/utils/w3.py
@@ -212,6 +212,8 @@ def build_standard_transaction(
     )
 
     tx["gas"] = w3.eth.estimate_gas(tx)
+    return tx
+
     return simulate_tx(w3, tx, account)
 
 
@@ -248,12 +250,14 @@ def send_and_confirm_tx(
     """Send and confirm transactions."""
 
     try:
+        
         tx_hash = sign_and_send_tx(w3=w3, tx=tx, private_key=private_key, logger=logger)
         tx_result = TxResult(tx_hash=tx_hash.to_0x_hex(), tx_receipt=None, exception=None)
+
     except Exception as send_err:
         msg = f"❌ Failed to send tx for {action}, error: {send_err!r}"
         logger.error(msg)
-        raise TxSubmissionError(msg) from send_err
+        return TxResult(exception=send_err, tx_hash=None, tx_receipt=None)
 
     try:
         tx_receipt = wait_for_tx_receipt(w3=w3, tx_hash=tx_hash)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -225,7 +225,6 @@ def test_get_collaterals(derive_client):
     assert isinstance(collaterals, list)
 
 
-@pytest.mark.skip("This test is not working on testnet due to rate limiting")
 def test_get_tickers(derive_client):
     """Test get tickers."""
     tickers = derive_client.fetch_tickers()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ from derive_client.data_types import (
     SubaccountType,
     UnderlyingCurrency,
 )
+from derive_client.utils import wait_until
 
 
 @pytest.mark.parametrize(
@@ -206,10 +207,21 @@ def test_cancel_all_orders(derive_client):
         side=OrderSide.BUY,
         order_type=OrderType.LIMIT,
     )
-    open_orders = derive_client.fetch_orders(status="open")
+    open_orders = wait_until(
+        func=derive_client.fetch_orders,
+        condition=lambda orders: orders,
+        status="open",
+        timeout_message="Orders not openened",
+    )
     assert open_orders
+
     derive_client.cancel_all()
-    open_orders = derive_client.fetch_orders(status="open")
+    open_orders = wait_until(
+        func=derive_client.fetch_orders,
+        condition=lambda orders: not orders,
+        status="open",
+        timeout_message="Outstanding orders not cancelled",
+    )
     assert not open_orders
 
 

--- a/tests/test_w3.py
+++ b/tests/test_w3.py
@@ -3,6 +3,7 @@ import time
 import warnings
 from http import HTTPStatus
 
+import certifi
 import pytest
 from requests.exceptions import RequestException
 from web3 import Web3
@@ -48,7 +49,7 @@ def test_rpc_endpoints_reachability_and_chain_id(chain, rpc_endpoints):
     failed = {}
     rate_limited = set()
 
-    request_kwargs = {"timeout": 1}
+    request_kwargs = {"timeout": 1, "verify": certifi.where()}
     providers = [HTTPProvider(url, request_kwargs) for url in rpc_endpoints]
     for provider in providers:
         w3 = Web3(provider)
@@ -91,7 +92,8 @@ def test_rpc_methods_supported(chain, rpc_endpoints):
     missing = {}
     exceptions = {}
     for url in rpc_endpoints:
-        prov = HTTPProvider(url)
+        request_kwargs = {"verify": certifi.where()}
+        prov = HTTPProvider(url,request_kwargs=request_kwargs)
         w3 = Web3(prov)
 
         for method, params in REQUIRED_METHODS.items():
@@ -129,7 +131,7 @@ def test_rotating_middelware(chain, rpc_endpoints):
     # --------------------
 
     # 0) Timeout fast, otherwise any ReadTimeout (default 10s) will cause failure
-    request_kwargs = {"timeout": 1}
+    request_kwargs = {"timeout": 1, "verify": certifi.where()}
 
     # 1) Build your list of HTTPProvider, based on your RPCEndpoints
     used = set()


### PR DESCRIPTION
- **fix: handle DeriveJSONRPCErrorCode.RATE_LIMIT_EXCEEDED in _send_request**
- **feat: pass optional logger to get_retry_session**
- **feat: use get_retry_session in BaseClient._send_request**
- **chore: remove rerun flags from pytest in Makefile**
- **fix: use certify.where() to instantiate Web3 providers**
- **tests: add vertify.where() in w3 tests for rotating provider**
- **tests: turn TrackingHTTPProvider.make_request into a no-op**
- **fix: ensure Certifi CA bundle is used in CI**
- **feat: add custom timeout_message to wait_until helper**
- **fix: add wait_until in test_cancel_all_orders**
- **fix: move ws connection logic to WsClient and AsyncClient**
- **fix: remove CA bundle patching using Cerifi**
- **chore: remove 1rpc endpoints from the default RPC endpoints**
- **chore: rerun tests and remove make_requests from TrackingHTTPProvider test**
- **fix: utils.w3 module time.time -> time.monotonic and logging**
- **Update w3.py**
- **fixes/simulations-gas-fixes**
