### PR TITLE
Add pyyaml to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ returns = "^0.26.0"
 eth-typing = "<5"
 py-vollib = "^1.0.1"
 msgspec = "^0.19.0"
+pyyaml = ">=6.0.1"
 
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Adding missing pyyaml to dependencies, as certain versions of python do not come with it (e.g. python:12-slim)