### PR TITLE
feat/rfq improvements

### DIFF
--- a/derive_client/data_types/channel_models.py
+++ b/derive_client/data_types/channel_models.py
@@ -12,7 +12,6 @@ from derive_client.data_types.generated_models import (
     CancelReason,
     Direction,
     LegPricedSchema,
-    LegUnpricedSchema,
     LiquidityRole,
     MarginType,
     OrderResponseSchema,
@@ -23,6 +22,7 @@ from derive_client.data_types.generated_models import (
     PublicGetInstrumentParamsSchema,
     PublicGetOptionSettlementPricesParamsSchema,
     PublicMarginWatchResultSchema,
+    RFQResultPublicSchema,
     RPCErrorFormatSchema,
     Status,
     TickerSlimSchema,
@@ -312,24 +312,6 @@ class TradesInstrumentTypeCurrencyPubSubSchema(Struct):
 class TradesInstrumentTypeCurrencyTxStatusNotificationParamsSchema(Struct):
     channel: str
     data: List[TradeSettledPublicResponseSchema]
-
-
-class RFQResultPublicSchema(Struct):
-    cancel_reason: CancelReason
-    creation_timestamp: int
-    filled_direction: Direction
-    filled_pct: Decimal
-    last_update_timestamp: int
-    legs: List[LegUnpricedSchema]
-    partial_fill_step: Decimal
-    rfq_id: str
-    status: Status
-    subaccount_id: int
-    valid_until: int
-    wallet: str
-    fill_rate: Optional[Decimal] = None
-    recent_fill_rate: Optional[Decimal] = None
-    total_cost: Optional[Decimal] = None
 
 
 class AuctionsWatchNotificationParamsSchema(Struct):

--- a/examples/rfqs/poll_rfq.py
+++ b/examples/rfqs/poll_rfq.py
@@ -3,7 +3,7 @@ Example of how to poll RFQ (Request for Quote) status and handle transfers betwe
 """
 
 import asyncio
-from time import sleep
+from typing import Sequence
 
 from config import ADMIN_TEST_WALLET as TEST_WALLET
 from config import SESSION_KEY_PRIVATE_KEY
@@ -12,11 +12,10 @@ from rich import print
 from derive_client import WebSocketClient
 from derive_client._clients.utils import DeriveJSONRPCError
 from derive_client.data_types import Environment
+from derive_client.data_types.channel_models import RFQResultPublicSchema
 from derive_client.data_types.generated_models import (
     Direction,
     LegPricedSchema,
-    RFQResultPublicSchema,
-    Status,
 )
 from derive_client.data_types.utils import D
 
@@ -57,36 +56,42 @@ async def main():
         env=Environment.TEST,
         subaccount_id=SUBACCOUNT_ID,
     )
-
-    async def on_rfq(rfq: RFQResultPublicSchema):
-        # here we get a price for the rfq.
-        # we first get the index price for the instrument
-        print(f"Received RFQ: {rfq}")
-        priced_legs = await create_priced_legs(client, rfq)
-        print(f"Total legs price: {sum([leg.price * leg.amount for leg in priced_legs])}")
-        try:
-            await client.rfq.send_quote(rfq_id=rfq.rfq_id, legs=priced_legs, direction=Direction.sell)
-        except DeriveJSONRPCError as e:
-            print(f"Error creating quote for RFQ {rfq.rfq_id}: {e}")
-            return
-
     await client.connect()
 
-    rfqs = []
-    from_timestamp = 0
-    while True:
-        new_rfqs = await client.rfq.poll_rfqs(from_timestamp=from_timestamp)
-        for rfq in new_rfqs.rfqs:
-            if rfq.last_update_timestamp > from_timestamp:
-                from_timestamp = rfq.last_update_timestamp + 1
-            if rfq.status is Status.open:
-                task = asyncio.create_task(on_rfq(rfq))
-                rfqs.append(task)
-        for task in rfqs:
-            if task.done():
-                rfqs.remove(task)
+    async def on_rfq(rfqs: Sequence[RFQResultPublicSchema]):
+        # here we get a price for the rfq.
+        # we first get the index price for the instrument
+        print(f"Received {len(rfqs)} RFQs")
+        for rfq in rfqs:
+            priced_legs = await create_priced_legs(client, rfq)
+            print(f"Total legs price: {sum([leg.price * leg.amount for leg in priced_legs])}")
+            try:
+                await client.rfq.send_quote(rfq_id=rfq.rfq_id, legs=priced_legs, direction=Direction.sell)
+            except DeriveJSONRPCError as e:
+                print(f"Error creating quote for RFQ {rfq.rfq_id}: {e}")
 
-        sleep(SLEEP_TIME)
+    await client.private_channels.rfqs_by_wallet(
+        wallet=TEST_WALLET,
+        callback=on_rfq,
+    )
+
+    await asyncio.Event().wait()
+
+    # rfqs = []
+    # from_timestamp = 0
+    # while True:
+    #     new_rfqs = await client.rfq.poll_rfqs(from_timestamp=from_timestamp)
+    #     for rfq in new_rfqs.rfqs:
+    #         if rfq.last_update_timestamp > from_timestamp:
+    #             from_timestamp = rfq.last_update_timestamp + 1
+    #         if rfq.status is Status.open:
+    #             task = asyncio.create_task(on_rfq(rfq))
+    #             rfqs.append(task)
+    #     for task in rfqs:
+    #         if task.done():
+    #             rfqs.remove(task)
+
+    #     sleep(SLEEP_TIME)
 
 
 if __name__ == "__main__":

--- a/specs/channels/channel.wallet.rfqs.json
+++ b/specs/channels/channel.wallet.rfqs.json
@@ -121,6 +121,7 @@
             "buy",
             "sell"
           ],
+          "nullable": true,
           "description": "Direction at which the RFQ was filled (only if filled)"
         },
         "filled_pct": {

--- a/specs/websocket-channels.json
+++ b/specs/websocket-channels.json
@@ -2931,6 +2931,7 @@
             "buy",
             "sell"
           ],
+          "nullable": true,
           "description": "Direction at which the RFQ was filled (only if filled)"
         },
         "filled_pct": {


### PR DESCRIPTION
- **feat:simple-ws-rfq-example**
- **feat:ensured-parsing-of-msg-spec-not-increibly-inefficient**
- **feat:started-async-ws-client**
- **feat:ensured-example-runs-async**
- **feat:updated-async-template-generation**
- **feat:fully-converted-websockets-to-async**
- **chore:linters**
- **fixes-for-linters**
- **chores:simple-quoter**
- **feat:ensured-simple-quoter-works**
- **feat:updated-rfq-channels-as-necessary**



Implements a simple naive rfq quoter;

<img width="1405" height="270" alt="image" src="https://github.com/user-attachments/assets/08206ab8-b08a-493a-a32f-0e998a9fd695" />


Also a simple rfq taker.
<img width="1227" height="287" alt="image" src="https://github.com/user-attachments/assets/db75d8d9-2e68-4c9a-83c4-ec4160f929fd" />
