### PR TITLE
fix: WebSocket reconnect tear down a part-way open() and confirm the subscribe reply

### DIFF
--- a/derive_client/_clients/utils.py
+++ b/derive_client/_clients/utils.py
@@ -236,6 +236,39 @@ def decode_result(envelope: JSONRPCEnvelope, result_schema: type[T]) -> T:
     return msgspec.json.decode(envelope.result, type=result_schema)
 
 
+class SubscribeAck(msgspec.Struct):
+    """Subscribe reply. `status` defaults because it only explains a refusal."""
+
+    current_subscriptions: list[str]
+    status: dict[str, str] = {}
+
+
+def confirm_subscriptions(channels: Iterable[str], envelope: JSONRPCEnvelope) -> tuple[list[str], dict[str, str]]:
+    """
+    Split channels into the confirmed ones, and the refused ones with their reason.
+
+    `current_subscriptions` holds what the connection is subscribed to after
+    the call, so it decides; `status` is free text on failure and only
+    explains. An unusable reply raises: that is a connection problem.
+    """
+
+    if envelope.error is not msgspec.UNSET:
+        raise ConnectionError(f"subscribe was refused: {msgspec.json.decode(envelope.error)}")
+
+    if envelope.result is msgspec.UNSET:
+        raise ConnectionError("subscribe reply carries neither result nor error")
+
+    ack = msgspec.json.decode(envelope.result, type=SubscribeAck)
+    live = set(ack.current_subscriptions)
+    confirmed = [channel for channel in channels if channel in live]
+    refused = {
+        channel: ack.status.get(channel) or "not listed in current_subscriptions"
+        for channel in channels
+        if channel not in live
+    }
+    return confirmed, refused
+
+
 def encode_json_exclude_none(obj: msgspec.Struct) -> bytes:
     """
     Encode msgspec Struct omitting None values.

--- a/derive_client/_clients/websockets/session.py
+++ b/derive_client/_clients/websockets/session.py
@@ -54,9 +54,11 @@ class ConnectionState:
             self._reconnecting = True
             return True
 
-    async def end_reconnect(self):
+    async def end_reconnect(self) -> bool:
+        """Release the claim. True if the session still needs a reconnect."""
         async with self._lock:
             self._reconnecting = False
+            return not self._connected
 
     async def is_connected(self) -> bool:
         async with self._lock:
@@ -153,10 +155,16 @@ class WebSocketSession:
             return
 
         await self._connect(mark_connected=False)
-        # Handlers survive close(), so reopening has to restore them too.
-        if self._handlers:
-            await self._before_resubscribe()
-            await self._resubscribe_all()
+        try:
+            # Handlers survive close(), so reopening has to restore them too.
+            if self._handlers:
+                await self._before_resubscribe()
+                await self._resubscribe_all()
+        except Exception:
+            # A part-way open looks healthy to the venue and delivers nothing,
+            # and the next open() would dial on top of its receiver.
+            await self._close_connection()
+            raise
         await self._state.set_connected()
 
     async def close(self) -> None:
@@ -167,17 +175,14 @@ class WebSocketSession:
         self._logger.info("Closing WebSocket session")
         self._stop_event.set()
 
-        # Close WebSocket
-        await self._close_connection()
-
-        # Cancel background tasks
-        for task in [self._receiver_task, self._reconnect_task]:
-            if task and not task.done():
-                task.cancel()
-                await self._reap(task)
-
-        self._receiver_task = None
+        # Stop the reconnect loop first: one that is already past its stop
+        # check can finish dialling and leave a fresh socket behind us.
+        await self._cancel(self._reconnect_task)
         self._reconnect_task = None
+
+        # Close WebSocket, which also stops the receiver task
+        await self._close_connection()
+        self._receiver_task = None
 
         # Wait for handler tasks to complete (with timeout)
         if self._handler_tasks:
@@ -245,6 +250,11 @@ class WebSocketSession:
         self._logger.info(f"Subscribing to channel: {channel}")
         try:
             envelope = await self._send_request("subscribe", params=params)
+            # A handler kept for a channel that never subscribed is silent for
+            # the life of the session, and asked for again on every reconnect.
+            confirmed, refused = confirm_subscriptions([channel], envelope)
+            if not confirmed:
+                raise ConnectionError(f"{channel} is not subscribed: the venue refuses it ({refused[channel]})")
             self._logger.debug(f"Subscribe RPC response for {channel}: {envelope}")
             return envelope
         except Exception:
@@ -316,13 +326,18 @@ class WebSocketSession:
         except Exception as e:
             self._logger.debug(f"Task {task.get_name()} ended with {e!r}")
 
+    async def _cancel(self, task: asyncio.Task | None) -> None:
+        """Cancel a task and wait for it to finish."""
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        task.cancel()
+        await self._reap(task)
+
     async def _close_connection(self) -> None:
         """Close the WebSocket connection and stop its receiver task."""
         task = self._receiver_task
         self._receiver_task = None
-        if task is not None and task is not asyncio.current_task():
-            task.cancel()
-            await self._reap(task)
+        await self._cancel(task)
 
         if self._ws:
             try:
@@ -369,7 +384,14 @@ class WebSocketSession:
             await self._reconnect_until_subscribed()
         finally:
             # Releasing here always: a stuck claim would strand the session.
-            await self._state.end_reconnect()
+            # A drop that landed while this loop was finishing could not claim
+            # the reconnect, so it is handed a fresh loop instead.
+            if await self._state.end_reconnect() and self._reconnect_enabled and not self._stop_event.is_set():
+                self._logger.warning("Disconnected while finishing the reconnect, restarting")
+                self._reconnect_task = asyncio.create_task(
+                    self._reconnect_loop(),
+                    name="ws-reconnect",
+                )
 
     async def _reconnect_until_subscribed(self) -> None:
         delay = self._reconnect_delay
@@ -488,7 +510,10 @@ class WebSocketSession:
 
     async def _send_request(self, method: str, params: msgspec.Struct | dict) -> JSONRPCEnvelope:
         """Send RPC request and return decoded envelope."""
-        if not self._ws:
+        # Bind to one connection: a reconnect in flight must not divert this
+        # request onto a socket it was not written for, nor clear it mid-send.
+        ws = self._ws
+        if ws is None:
             raise RuntimeError("WebSocket not connected")
 
         request_id = str(uuid.uuid4())
@@ -513,7 +538,7 @@ class WebSocketSession:
             self._pending_requests[request_id] = response_queue
 
         try:
-            await self._ws.send(data)
+            await ws.send(data)
 
             try:
                 envelope = await asyncio.wait_for(response_queue.get(), timeout=self._request_timeout)

--- a/derive_client/_clients/websockets/session.py
+++ b/derive_client/_clients/websockets/session.py
@@ -5,7 +5,6 @@ Asynchronous WebSocket session with automatic reconnection and auth hook.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import inspect
 import uuid
 import weakref
@@ -17,7 +16,7 @@ from websockets import Data
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.exceptions import ConnectionClosed
 
-from derive_client._clients.utils import JSONRPCEnvelope, decode_envelope
+from derive_client._clients.utils import JSONRPCEnvelope, confirm_subscriptions, decode_envelope
 from derive_client.data_types import LoggerType
 from derive_client.utils.logger import get_logger
 
@@ -42,15 +41,22 @@ class ConnectionState:
     async def set_connected(self):
         async with self._lock:
             self._connected = True
-            self._reconnecting = False
 
     async def set_disconnected(self):
         async with self._lock:
             self._connected = False
 
-    async def set_reconnecting(self):
+    async def begin_reconnect(self) -> bool:
+        """Claim the reconnect. False if another loop already holds it."""
         async with self._lock:
+            if self._reconnecting:
+                return False
             self._reconnecting = True
+            return True
+
+    async def end_reconnect(self):
+        async with self._lock:
+            self._reconnecting = False
 
     async def is_connected(self) -> bool:
         async with self._lock:
@@ -136,12 +142,22 @@ class WebSocketSession:
         self._finalizer = weakref.finalize(self, self._finalize, logger=self._logger)
 
     async def open(self) -> None:
-        """Establish WebSocket connection and start receiver task."""
+        """Establish WebSocket connection, start receiver task, restore handlers."""
         if await self._state.is_connected():
             self._logger.warning("WebSocket already connected")
             return
 
-        await self._connect()
+        if await self._state.is_reconnecting():
+            # Connecting under the reconnect would orphan its socket and receiver.
+            self._logger.warning("Reconnection in progress, not opening a second connection")
+            return
+
+        await self._connect(mark_connected=False)
+        # Handlers survive close(), so reopening has to restore them too.
+        if self._handlers:
+            await self._before_resubscribe()
+            await self._resubscribe_all()
+        await self._state.set_connected()
 
     async def close(self) -> None:
         """Close connection and stop all tasks. Idempotent."""
@@ -158,8 +174,7 @@ class WebSocketSession:
         for task in [self._receiver_task, self._reconnect_task]:
             if task and not task.done():
                 task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                await self._reap(task)
 
         self._receiver_task = None
         self._reconnect_task = None
@@ -265,7 +280,7 @@ class WebSocketSession:
             self._logger.exception(f"Unsubscribe RPC failed for {channel}")
             raise
 
-    async def _connect(self) -> None:
+    async def _connect(self, mark_connected: bool = True) -> None:
         """Establish WebSocket connection and start receiver task."""
         self._logger.info(f"Connecting to {self._url}")
 
@@ -280,7 +295,9 @@ class WebSocketSession:
             self._logger.error(f"Connection failed: {e}")
             raise
 
-        await self._state.set_connected()
+        # Reconnection marks the session connected only once resubscribed.
+        if mark_connected:
+            await self._state.set_connected()
 
         # Start receiver task
         self._stop_event.clear()
@@ -288,8 +305,25 @@ class WebSocketSession:
 
         self._logger.info("WebSocket connected, receiver task started")
 
+    async def _reap(self, task: asyncio.Task) -> None:
+        """Await a cancelled task without adopting how it died."""
+        # Callers are tearing a connection down; adopting the task's own
+        # exception would abandon that teardown half-finished.
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self._logger.debug(f"Task {task.get_name()} ended with {e!r}")
+
     async def _close_connection(self) -> None:
-        """Close the WebSocket connection."""
+        """Close the WebSocket connection and stop its receiver task."""
+        task = self._receiver_task
+        self._receiver_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            await self._reap(task)
+
         if self._ws:
             try:
                 await self._ws.close()
@@ -318,19 +352,30 @@ class WebSocketSession:
                 self._logger.error(f"Error in on_disconnect callback: {e}")
 
         # Start reconnection if enabled
-        if self._reconnect_enabled and not await self._state.is_reconnecting():
-            await self._state.set_reconnecting()
-            self._reconnect_task = asyncio.create_task(
-                self._reconnect_loop(),
-                name="ws-reconnect",
-            )
+        if self._reconnect_enabled and await self._state.begin_reconnect():
+            try:
+                self._reconnect_task = asyncio.create_task(
+                    self._reconnect_loop(),
+                    name="ws-reconnect",
+                )
+            except Exception:
+                # Nothing will release the claim if the loop never starts.
+                await self._state.end_reconnect()
+                raise
 
     async def _reconnect_loop(self) -> None:
         """Reconnection loop with exponential backoff."""
+        try:
+            await self._reconnect_until_subscribed()
+        finally:
+            # Releasing here always: a stuck claim would strand the session.
+            await self._state.end_reconnect()
+
+    async def _reconnect_until_subscribed(self) -> None:
         delay = self._reconnect_delay
         attempt = 1
 
-        while not self._stop_event.is_set() and not await self._state.is_connected():
+        while not self._stop_event.is_set():
             self._logger.info(f"Reconnection attempt {attempt} in {delay:.1f}s")
             await asyncio.sleep(delay)
 
@@ -341,8 +386,9 @@ class WebSocketSession:
                 # Close old connection if exists
                 await self._close_connection()
 
-                # Establish new connection
-                await self._connect()
+                # Not connected until resubscribed - that is what makes it usable.
+                await self._connect(mark_connected=False)
+                connection = self._ws
 
                 # Call reconnect callback (for re-auth, etc.)
                 if self._on_reconnect is not None:
@@ -355,31 +401,44 @@ class WebSocketSession:
                         # Don't fail reconnection if callback fails
 
                 # Call before_resubscribe callback (for re-authentication)
-                if self._on_before_resubscribe is not None:
-                    try:
-                        res = self._on_before_resubscribe()
-                        if inspect.isawaitable(res):
-                            await cast(Awaitable[None], res)
-                    except Exception as e:
-                        self._logger.error(f"Error in on_before_resubscribe callback: {e}")
-                        raise  # Re-auth failure should trigger retry
+                await self._before_resubscribe()
 
                 # Resubscribe to all channels
                 await self._resubscribe_all()
 
+                # A drop in the window above leaves no receiver to report it.
+                if self._ws is not connection or connection is None or connection.close_code is not None:
+                    raise ConnectionError("connection dropped before resubscribing finished")
+
+                await self._state.set_connected()
                 self._logger.info(f"Reconnected successfully after {attempt} attempts")
                 return
 
             except Exception as e:
                 self._logger.error(f"Reconnection attempt {attempt} failed: {e}")
+                # A part-way connection looks healthy and delivers nothing.
+                await self._close_connection()
                 attempt += 1
                 delay = min(delay * 2, self._max_reconnect_delay)
 
         await self._state.set_disconnected()
         self._logger.info("Reconnection stopped")
 
+    async def _before_resubscribe(self) -> None:
+        """Run the re-auth callback. Its failure has to fail the attempt."""
+
+        if self._on_before_resubscribe is None:
+            return
+        try:
+            res = self._on_before_resubscribe()
+            if inspect.isawaitable(res):
+                await cast(Awaitable[None], res)
+        except Exception as e:
+            self._logger.error(f"Error in on_before_resubscribe callback: {e}")
+            raise  # Re-auth failure should trigger retry
+
     async def _resubscribe_all(self) -> None:
-        """Resubscribe to all channels after reconnection."""
+        """Resubscribe every channel, and raise unless some came back."""
         async with self._handlers_lock:
             channels = list(self._handlers.keys())
 
@@ -388,15 +447,44 @@ class WebSocketSession:
             return
 
         self._logger.info(f"Resubscribing to {len(channels)} channels")
+        confirmed, refused = await self._subscribe_batch(channels)
 
+        # Nothing subscribed is a connection failure - a rejected re-auth
+        # looks exactly like this - but a channel the venue will not serve
+        # must not fail the attempt, or one delisted instrument would end all
+        # market data. It stays registered and is tried again next reconnect.
+        if not confirmed:
+            raise ConnectionError(f"no channel came back: {refused}")
+
+        for channel, reason in refused.items():
+            self._logger.error(f"{channel} is not subscribed: the venue refuses it ({reason})")
+
+        self._logger.debug(f"Resubscribed to {len(confirmed)} channels")
+
+    async def _subscribe_batch(self, channels: list[str]) -> tuple[list[str], dict[str, str]]:
+        """Subscribe in one request, falling back to one at a time."""
+
+        # One request, not one per channel: a channel at a time spends the
+        # request budget and then fails the reconnect on the rejections it
+        # caused. A single bad channel is answered with `Invalid params` for
+        # the whole request, hence the fallback below.
+        envelope = await self._send_request("subscribe", params=Subscribe(channels=channels))
+        if envelope.error is msgspec.UNSET:
+            return confirm_subscriptions(channels, envelope)
+
+        self._logger.warning(f"Subscribe rejected for {len(channels)} channels at once, asking one at a time")
+        confirmed: list[str] = []
+        refused: dict[str, str] = {}
         for channel in channels:
             try:
-                params = Subscribe(channels=[channel])
-                envelope = await self._send_request("subscribe", params=params)
-                self._logger.debug(f"Resubscribed to {channel}: {envelope}")
-            except Exception as e:
-                self._logger.error(f"Failed to resubscribe to {channel}: {e}")
-                # Continue trying other channels
+                reply = await self._send_request("subscribe", params=Subscribe(channels=[channel]))
+                accepted, rejected = confirm_subscriptions([channel], reply)
+            except ConnectionError as e:
+                refused[channel] = str(e)
+                continue
+            confirmed.extend(accepted)
+            refused.update(rejected)
+        return confirmed, refused
 
     async def _send_request(self, method: str, params: msgspec.Struct | dict) -> JSONRPCEnvelope:
         """Send RPC request and return decoded envelope."""

--- a/derive_client/data/rpc_endpoints.yaml
+++ b/derive_client/data/rpc_endpoints.yaml
@@ -38,7 +38,7 @@ ARBITRUM:
 
 DERIVE:
   - https://rpc.derive.xyz/
-  - https://957.rpc.thirdweb.com/
+  # - https://957.rpc.thirdweb.com/
 
 MODE:
   - https://mode.drpc.org

--- a/tests/test_clients/test_websocket/test_reconnect_resubscribe.py
+++ b/tests/test_clients/test_websocket/test_reconnect_resubscribe.py
@@ -358,3 +358,58 @@ async def test_overlapping_reconnects_do_not_storm_or_lose_the_channel():
         # One reconnect per drop, give or take; a storm is hundreds.
         assert venue.seen["connections"] < 15, f"reconnect storm: {venue.seen['connections']} connections for 10 drops"
         await _assert_delivers(venue, received, "survived the drops, but the channel is silent")
+
+
+def _live(venue: FakeVenue) -> int:
+    """Connections the venue still has open."""
+    return len(venue._subscriptions)
+
+
+async def _eventually(predicate, timeout: float = 2.0) -> bool:
+    """Poll for a condition: a socket closes on both ends, not just ours."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.05)
+    return predicate()
+
+
+@pytest.mark.asyncio
+async def test_an_open_that_cannot_restore_leaves_nothing_behind():
+    """
+    Test that an open() which fails to restore its channels closes its socket.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        await session.close()
+
+        venue.refuse[CHANNEL] = "not authenticated"
+        with pytest.raises(ConnectionError):
+            await session.open()
+
+        assert await _eventually(lambda: _live(venue) == 0), "the failed open() left a connection open"
+
+        venue.refuse.clear()
+        await session.open()
+        assert _live(venue) == 1, "reopening dialled on top of the failed open()"
+        await _assert_delivers(venue, received, "reopened, but the channel is silent")
+
+
+@pytest.mark.asyncio
+async def test_subscribing_to_a_channel_the_venue_refuses_fails():
+    """
+    Test that a refused subscribe is reported rather than quietly registered.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        venue.refuse[OTHER] = "Channel does not exist"
+
+        with pytest.raises(ConnectionError):
+            await session.subscribe(OTHER, lambda _data: None, notification_type=dict)
+
+        assert await venue.publish(OTHER) == 0, "refused, yet reported as subscribed"
+        await _assert_delivers(venue, received, "a refused subscribe took the live channel down")

--- a/tests/test_clients/test_websocket/test_reconnect_resubscribe.py
+++ b/tests/test_clients/test_websocket/test_reconnect_resubscribe.py
@@ -1,0 +1,360 @@
+"""
+Offline tests for reconnection: a reconnect must restore subscriptions.
+
+Run against a local server, since the failures need a re-auth that fails,
+reconnects that overlap, and a venue that refuses channels. The fake venue
+only notifies connections that actually subscribed, so a session that
+reconnects without resubscribing goes silent, as it does live.
+"""
+
+import asyncio
+import json
+from collections import Counter
+from contextlib import asynccontextmanager
+
+import pytest
+from websockets.asyncio.server import serve
+
+from derive_client._clients.websockets.session import WebSocketSession
+
+CHANNEL = "test.channel"
+OTHER = "other.channel"
+# Live re-auth is a round trip over TLS; on loopback the race has no window.
+LOGIN_DELAY = 1.0
+REQUEST_TIMEOUT = 2.0
+
+
+class FakeVenue:
+    """Answers any RPC, records subscriptions, and can refuse or drop."""
+
+    def __init__(self, login_delay: float = 0.0) -> None:
+        self.seen: Counter = Counter()
+        self.login_delay = login_delay
+        # Set to "timeout", "error" or "drop" to break the next resubscribe.
+        self.fault: str | None = None
+        # Channel -> the reason the venue reports for refusing it.
+        self.refuse: dict[str, str] = {}
+        # Channels that make the venue reject the whole request they arrive
+        # in, the way a deprecated channel name does live.
+        self.poison: set[str] = set()
+        # "both", "status" or "subscriptions": which half of the ack to send.
+        self.ack = "both"
+        self._subscriptions: dict = {}
+
+    async def handler(self, websocket) -> None:
+        self.seen["connections"] += 1
+        self._subscriptions[websocket] = set()
+        try:
+            async for raw in websocket:
+                message = json.loads(raw)
+                method = message.get("method")
+                self.seen[f"rpc:{method}"] += 1
+
+                if method == "subscribe" and self.fault:
+                    if await self._break(websocket, message):
+                        return
+                    continue
+
+                if method == "public/login" and self.login_delay:
+                    await asyncio.sleep(self.login_delay)
+
+                reply = {"jsonrpc": "2.0", "id": message["id"], "result": {}}
+                if method == "subscribe":
+                    asked = message.get("params", {}).get("channels", [])
+                    if self.poison.intersection(asked):
+                        reply = {
+                            "jsonrpc": "2.0",
+                            "id": message["id"],
+                            "error": {"code": -32602, "message": "Invalid params"},
+                        }
+                    else:
+                        reply["result"] = self._subscribe(websocket, asked)
+                await websocket.send(json.dumps(reply))
+        except Exception:  # dropping clients is what this fixture is for
+            pass
+        finally:
+            self._subscriptions.pop(websocket, None)
+
+    def _subscribe(self, websocket, asked) -> dict:
+        status = {}
+        for channel in asked:
+            if channel in self.refuse:
+                status[channel] = self.refuse[channel]
+                continue
+            self._subscriptions[websocket].add(channel)
+            status[channel] = "ok"
+
+        result: dict = {}
+        if self.ack in ("both", "status"):
+            result["status"] = status
+        if self.ack in ("both", "subscriptions"):
+            result["current_subscriptions"] = sorted(self._subscriptions[websocket])
+        return result
+
+    async def _break(self, websocket, message) -> bool:
+        """Apply the armed fault. True when the connection is gone."""
+
+        if self.fault == "timeout":
+            return False  # never answer
+        if self.fault == "error":
+            error = {"code": -32000, "message": "not authenticated"}
+            await websocket.send(json.dumps({"jsonrpc": "2.0", "id": message["id"], "error": error}))
+            return False
+        self.fault = None  # "drop": only the first resubscribe dies
+        websocket.transport.abort()
+        return True
+
+    async def publish(self, channel: str) -> int:
+        """Notify subscribers of the channel, as the venue would."""
+        delivered = 0
+        for websocket, channels in list(self._subscriptions.items()):
+            if channel not in channels:
+                continue
+            try:
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "subscription",
+                            "params": {"channel": channel, "data": {"tick": 1}},
+                        }
+                    )
+                )
+                delivered += 1
+            except Exception:
+                pass
+        return delivered
+
+    async def drop_all(self) -> None:
+        """Kill sockets without a close frame, as a network failure does."""
+        for websocket in list(self._subscriptions):
+            try:
+                websocket.transport.abort()
+            except Exception:
+                await websocket.close(code=1006)
+            self._subscriptions.pop(websocket, None)
+
+
+@asynccontextmanager
+async def _settled(venue, port, received, on_before_resubscribe=None, channels=(CHANNEL,)):
+    """A session subscribed and proven to be delivering.
+
+    Closed in a `finally`: conftest shares one event loop, so a leaked session
+    keeps retrying a dead port for the whole run.
+    """
+
+    session = WebSocketSession(
+        url=f"ws://127.0.0.1:{port}",
+        request_timeout=REQUEST_TIMEOUT,
+        reconnect_delay=0.2,
+        on_before_resubscribe=on_before_resubscribe,
+    )
+    try:
+        await session.open()
+
+        async def on_message(_data):
+            received.append(_data)
+
+        for channel in channels:
+            await session.subscribe(channel, on_message, notification_type=dict)
+
+        assert await venue.publish(channels[0]) == 1
+        await asyncio.sleep(0.3)
+        assert received, "the channel was not delivering before the disconnect"
+        received.clear()
+        yield session
+    finally:
+        await session.close()
+
+
+async def _assert_delivers(venue, received, message: str, channel: str = CHANNEL) -> None:
+    received.clear()
+    assert await venue.publish(channel) == 1, message
+    await asyncio.sleep(0.3)
+    assert received, message
+
+
+@asynccontextmanager
+async def _venue(login_delay: float = 0.0):
+    venue = FakeVenue(login_delay=login_delay)
+    async with serve(venue.handler, "127.0.0.1", 0) as server:
+        yield venue, next(iter(server.sockets)).getsockname()[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fault, settle", [("timeout", 3.0), ("error", 1.5)])
+async def test_a_refused_resubscribe_is_not_a_reconnect(fault, settle):
+    """
+    Test that a resubscribe the venue does not confirm keeps the session down.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        venue.fault = fault
+        await venue.drop_all()
+        await asyncio.sleep(settle)
+
+        assert venue.seen["rpc:subscribe"] > 1, "the test never exercised a resubscribe"
+        assert not await session._state.is_connected(), "connected, but no channel came back"
+
+        venue.fault = None
+        await asyncio.sleep(4)
+        await _assert_delivers(venue, received, "the venue recovered and the channel did not")
+
+
+@pytest.mark.asyncio
+async def test_one_refused_channel_does_not_take_the_others_down():
+    """
+    Test that a channel the venue will not serve leaves the rest working.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received, channels=(CHANNEL, OTHER)) as session:
+        venue.refuse[OTHER] = "Channel does not exist"
+        await venue.drop_all()
+        await asyncio.sleep(4)
+
+        assert await session._state.is_connected(), "one bad channel took the session down"
+        await _assert_delivers(venue, received, "the healthy channel did not come back")
+        assert await venue.publish(OTHER) == 0, "the refused channel cannot be live"
+
+
+@pytest.mark.asyncio
+async def test_a_channel_the_venue_will_not_parse_does_not_silence_the_rest():
+    """
+    Test the fallback when the venue rejects the whole request over one channel.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received, channels=(CHANNEL, OTHER)) as session:
+        venue.poison.add(OTHER)
+        await venue.drop_all()
+        await asyncio.sleep(6)
+
+        assert await session._state.is_connected(), "one unparseable channel took the session down"
+        await _assert_delivers(venue, received, "the healthy channel did not come back")
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_that_leaves_nothing_is_a_failed_attempt():
+    """
+    Test that refusing every channel is treated as a connection failure.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        venue.refuse[CHANNEL] = "not authenticated"
+        await venue.drop_all()
+        await asyncio.sleep(4)
+
+        assert not await session._state.is_connected(), "connected with nothing subscribed"
+
+        venue.refuse.clear()
+        await asyncio.sleep(5)
+        await _assert_delivers(venue, received, "the venue recovered and the channel did not")
+
+
+@pytest.mark.asyncio
+async def test_current_subscriptions_decides_and_status_explains():
+    """
+    Test that confirmation comes from `current_subscriptions`, not `status`.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received, channels=(CHANNEL, OTHER)) as session:
+        venue.ack = "subscriptions"  # no status at all
+        await venue.drop_all()
+        await asyncio.sleep(2)
+        assert await session._state.is_connected(), "current_subscriptions alone did not confirm"
+        await _assert_delivers(venue, received, "reconnected, but the channel is silent")
+
+        venue.ack = "both"
+        venue.refuse[OTHER] = "Channel does not exist"
+        await venue.drop_all()
+        await asyncio.sleep(4)
+        assert await session._state.is_connected(), "a refused channel took the session down"
+        assert await venue.publish(OTHER) == 0, "refused, yet reported as subscribed"
+
+
+@pytest.mark.asyncio
+async def test_a_drop_while_resubscribing_does_not_strand_the_session():
+    """
+    Test that a disconnect inside the resubscribe window still recovers.
+
+    Passes against 0.3.15 too: it guards the new ownership model, not the bug.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        venue.fault = "drop"
+        await venue.drop_all()
+        await asyncio.sleep(5)
+
+        assert venue.fault is None, "the test never exercised a drop while resubscribing"
+        await _assert_delivers(venue, received, "reconnected, but the channel is silent")
+        assert await session._state.is_connected()
+
+
+@pytest.mark.asyncio
+async def test_reopening_a_closed_session_resubscribes():
+    """
+    Test that close() then open() does not come back silent.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        await session.close()
+        await session.open()
+
+        assert await session._state.is_connected()
+        await _assert_delivers(venue, received, "reopened, but the channel is silent")
+
+
+@pytest.mark.asyncio
+async def test_open_during_a_reconnect_is_refused():
+    """
+    Test that open() does not build a second connection under a reconnect.
+    """
+
+    received: list = []
+    async with _venue() as (venue, port), _settled(venue, port, received) as session:
+        venue.fault = "timeout"
+        await venue.drop_all()
+        await asyncio.sleep(1)
+        assert await session._state.is_reconnecting(), "the test never caught a reconnect"
+
+        await session.open()
+        assert not await session._state.is_connected(), "open() connected under the reconnect"
+
+        venue.fault = None
+        await asyncio.sleep(5)
+        await _assert_delivers(venue, received, "the reconnect did not survive the open()")
+
+
+@pytest.mark.asyncio
+async def test_overlapping_reconnects_do_not_storm_or_lose_the_channel():
+    """
+    Test that drops arriving faster than a reconnect completes do not pile up.
+    """
+
+    received: list = []
+    holder: dict = {}
+
+    async def reauth():
+        # A real round trip, so a racing reconnect has the same window as live.
+        await holder["session"]._send_request("public/login", {})
+
+    async with (
+        _venue(login_delay=LOGIN_DELAY) as (venue, port),
+        _settled(venue, port, received, on_before_resubscribe=reauth) as session,
+    ):
+        holder["session"] = session
+
+        for _ in range(10):
+            await venue.drop_all()
+            await asyncio.sleep(0.6)
+        await asyncio.sleep(10)
+
+        # One reconnect per drop, give or take; a storm is hundreds.
+        assert venue.seen["connections"] < 15, f"reconnect storm: {venue.seen['connections']} connections for 10 drops"
+        await _assert_delivers(venue, received, "survived the drops, but the channel is silent")


### PR DESCRIPTION
Builds on #210, which is included here. Closes #210.

Two cases #210 does not cover, each with a failing test first:

- `open()` that cannot restore its channels raised with the socket still open, so the next `open()` dialled a second one on top of its receiver
- `subscribe()` returned the reply unread, so a channel the venue refused stayed registered and silent for the life of the session

Also, without tests, since neither window is reachable from a fake venue: 
- release the reconnect claim and check the connection under one lock
- cancel the reconnect loop before tearing the connection down in `close()` 
- bind a request to one connection

The CI is expected not to pass at the moment tho, because the v2 testnet at [api-demo.lyra.finance](https://api-demo.lyra.finance/) is currently degraded